### PR TITLE
Bring back default config for AllCops/Include

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -3,11 +3,7 @@ AllCops:
   DisplayCopNames: true
   DisplayStyleGuide: true
   ExtraDetails: true
-  Include:
-    - Gemfile
-    - Rakefile
-    - config.ru
-    - '**/*.rake'
+
   Exclude:
     - .bundle/**/*
     - db/schema.rb

--- a/default.yml
+++ b/default.yml
@@ -544,6 +544,9 @@ RSpec/EmptyLineAfterSubject:
 RSpec/FilePath:
   Enabled: true
 
+Rails/InverseOf:
+  Enabled: false
+
 Rails/Present:
   Enabled: true
 

--- a/default.yml
+++ b/default.yml
@@ -545,7 +545,7 @@ RSpec/FilePath:
   Enabled: true
 
 Rails/InverseOf:
-  Enabled: false
+  Enabled: true
 
 Rails/Present:
   Enabled: true

--- a/lib/scc/codestyle/version.rb
+++ b/lib/scc/codestyle/version.rb
@@ -1,5 +1,5 @@
 module Scc
   module Codestyle
-    VERSION = '0.3.0'.freeze
+    VERSION = '0.3.1'.freeze
   end
 end


### PR DESCRIPTION
Removes our custom `AllCops/Include` setting as it overwrites default Rubocop patterns.

Behavior changed in 0.56.0 and we haven't noticed since Glue was still
running 0.52.0 and Duct-Tape wasn't running rubocop at all in its CI.

From https://docs.rubocop.org/en/stable/configuration/#includingexcluding-files:
![image](https://user-images.githubusercontent.com/5372947/71678028-6b753d80-2d84-11ea-803d-96c01d7c4394.png)
