### PR TITLE
Version 0.4.0

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -572,3 +572,12 @@ RSpec/AnyInstance:
 
 RSpec/PredicateMatcher:
   Enabled: false
+
+RSpec/RepeatedDescription:
+  Enabled: pending
+
+RSpec/RepeatedExampleGroupBody:
+  Enabled: pending
+
+RSpec/RepeatedExampleGroupDescription:
+  Enabled: pending

--- a/default.yml
+++ b/default.yml
@@ -210,9 +210,6 @@ Layout/SpaceInsideBlockBraces:
 Layout/SpaceBeforeBlockBraces:
   Enabled: true
 
-Style/BracesAroundHashParameters:
-  Enabled: false
-
 Layout/TrailingEmptyLines:
   Enabled: true
 

--- a/lib/scc/codestyle/version.rb
+++ b/lib/scc/codestyle/version.rb
@@ -1,5 +1,5 @@
 module Scc
   module Codestyle
-    VERSION = '0.3.2'.freeze
+    VERSION = '0.4.0'.freeze
   end
 end


### PR DESCRIPTION
Now using rubocop 0.80.0 which introduced the `Enabled: pending` feature for new cops.

Seems the new cops coming from the rubocop-rspec gem are not yet using that, probably came out before the `pending` feature was available (or don't use it for backwards compatibly) :man_shrugging: 
But we can set those manually to be pending.

As soon as this PR is merged, I release the new version to rubygems.org so we can use it in Glue (and eventually all our projects).