### PR TITLE
Update rubocop rules

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -715,8 +715,6 @@ Performance/StringInclude: # (new in 1.7)
   Enabled: true
 Performance/Sum: # (new in 1.8)
   Enabled: true
-Gemspec/DateAssignment: # new in 1.10
-  Enabled: true
 Gemspec/DeprecatedAttributeAssignment:
   Enabled: true
 Layout/LineEndStringConcatenationIndentation: # new in 1.18
@@ -839,6 +837,8 @@ Rails/I18nLocaleAssignment: # new in 2.11
 Rails/Inquiry: # new in 2.7
   Enabled: true
 Rails/MailerName: # new in 2.7
+  Enabled: true
+Rails/ExpandedDateRange: # new in 2.11
   Enabled: true
 Rails/MatchRoute: # new in 2.7
   Enabled: true

--- a/lib/scc/codestyle/version.rb
+++ b/lib/scc/codestyle/version.rb
@@ -1,5 +1,5 @@
 module Scc
   module Codestyle
-    VERSION = '0.6.0'.freeze
+    VERSION = '0.6.1'.freeze
   end
 end


### PR DESCRIPTION
On `Subhub` we are getting the following error:

```
Error: The `Gemspec/DateAssignment` cop has been removed. Please use `Gemspec/DeprecatedAttributeAssignment` instead.
(obsolete configuration found in /home/subhub/.bundle/ruby/2.7.0/gems/scc-codestyle-0.6.0/default.yml, please update it)
```