### PR TITLE
Update rubocop and its modules

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -875,3 +875,122 @@ RSpec/SubjectDeclaration: # new in 2.5
   Enabled: true
 RSpec/Rails/AvoidSetupHook: # new in 2.4
   Enabled: true
+Layout/LineContinuationLeadingSpace: # new in 1.31
+  Enabled: true
+Layout/LineContinuationSpacing: # new in 1.31
+  Enabled: true
+Lint/ConstantOverwrittenInRescue: # new in 1.31
+  Enabled: true
+Lint/DuplicateMagicComment: # new in 1.37
+  Enabled: true
+Lint/NonAtomicFileOperation: # new in 1.31
+  Enabled: true
+Lint/RefinementImportMethods: # new in 1.27
+  Enabled: true
+Lint/RequireRangeParentheses: # new in 1.32
+  Enabled: true
+Lint/UselessRuby2Keywords: # new in 1.23
+  Enabled: true
+Naming/BlockForwarding: # new in 1.24
+  Enabled: true
+Security/CompoundHash: # new in 1.28
+  Enabled: true
+Style/EmptyHeredoc: # new in 1.32
+  Enabled: true
+Style/EnvHome: # new in 1.29
+  Enabled: true
+Style/FetchEnvVar: # new in 1.28
+  Enabled: true
+Style/FileRead: # new in 1.24
+  Enabled: true
+Style/FileWrite: # new in 1.24
+  Enabled: true
+Style/MagicCommentFormat: # new in 1.35
+  Enabled: true
+Style/MapCompactWithConditionalBlock: # new in 1.30
+  Enabled: true
+Style/MapToHash: # new in 1.24
+  Enabled: true
+Style/NestedFileDirname: # new in 1.26
+  Enabled: true
+Style/ObjectThen: # new in 1.28
+  Enabled: true
+Style/OpenStructUse: # new in 1.23
+  Enabled: true
+Style/OperatorMethodCall: # new in 1.37
+  Enabled: true
+Style/RedundantInitialize: # new in 1.27
+  Enabled: true
+Style/RedundantStringEscape: # new in 1.37
+  Enabled: true
+Performance/ConcurrentMonotonicTime: # new in 1.12
+  Enabled: true
+Performance/StringIdentifierArgument: # new in 1.13
+  Enabled: true
+Rails/ActionControllerFlashBeforeRender: # new in 2.16
+  Enabled: true
+Rails/ActionControllerTestCase: # new in 2.14
+  Enabled: true
+Rails/ActiveSupportOnLoad: # new in 2.16
+  Enabled: true
+Rails/CompactBlank: # new in 2.13
+  Enabled: true
+Rails/DeprecatedActiveModelErrorsMethods: # new in 2.14
+  Enabled: true
+Rails/DotSeparatedKeys: # new in 2.15
+  Enabled: true
+Rails/DuplicateAssociation: # new in 2.14
+  Enabled: true
+Rails/DuplicateScope: # new in 2.14
+  Enabled: true
+Rails/DurationArithmetic: # new in 2.13
+  Enabled: true
+Rails/FreezeTime: # new in 2.16
+  Enabled: true
+Rails/I18nLazyLookup: # new in 2.14
+  Enabled: true
+Rails/I18nLocaleTexts: # new in 2.14
+  Enabled: true
+Rails/MigrationClassName: # new in 2.14
+  Enabled: true
+Rails/RedundantPresenceValidationOnBelongsTo: # new in 2.13
+  Enabled: true
+Rails/RootJoinChain: # new in 2.13
+  Enabled: true
+Rails/RootPathnameMethods: # new in 2.16
+  Enabled: true
+Rails/RootPublicPath: # new in 2.15
+  Enabled: true
+Rails/StripHeredoc: # new in 2.15
+  Enabled: true
+Rails/ToFormattedS: # new in 2.15
+  Enabled: true
+Rails/ToSWithArgument: # new in 2.16
+  Enabled: true
+Rails/TopLevelHashWithIndifferentAccess: # new in 2.16
+  Enabled: true
+Rails/TransactionExitStatement: # new in 2.14
+  Enabled: true
+Rails/WhereMissing: # new in 2.16
+  Enabled: true
+RSpec/BeEq: # new in 2.9.0
+  Enabled: true
+RSpec/BeNil: # new in 2.9.0
+  Enabled: true
+RSpec/ChangeByZero: # new in 2.11
+  Enabled: true
+RSpec/ClassCheck: # new in 2.13
+  Enabled: true
+RSpec/NoExpectationExample: # new in 2.13
+  Enabled: true
+RSpec/VerifiedDoubleReference: # new in 2.10.0
+  Enabled: true
+RSpec/Capybara/SpecificFinders: # new in 2.13
+  Enabled: true
+RSpec/Capybara/SpecificMatcher: # new in 2.12
+  Enabled: true
+RSpec/FactoryBot/SyntaxMethods: # new in 2.7
+  Enabled: true
+RSpec/Rails/HaveHttpStatus: # new in 2.12
+  Enabled: true
+

--- a/lib/scc/codestyle/version.rb
+++ b/lib/scc/codestyle/version.rb
@@ -1,5 +1,5 @@
 module Scc
   module Codestyle
-    VERSION = '0.6.2'.freeze
+    VERSION = '0.6.3'.freeze
   end
 end

--- a/scc-codestyle.gemspec
+++ b/scc-codestyle.gemspec
@@ -19,11 +19,11 @@ Gem::Specification.new do |spec|
   end
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'rubocop', '~> 1.22'
-  spec.add_dependency 'rubocop-performance', '~> 1.11'
-  spec.add_dependency 'rubocop-rails', '~> 2.12'
+  spec.add_dependency 'rubocop', '~> 1.37'
+  spec.add_dependency 'rubocop-performance', '~> 1.15'
+  spec.add_dependency 'rubocop-rails', '~> 2.16'
   spec.add_dependency 'rubocop-rake', '~> 0.6'
-  spec.add_dependency 'rubocop-rspec', '~> 2.5'
+  spec.add_dependency 'rubocop-rspec', '~> 2.13'
   spec.add_dependency 'rubocop-thread_safety', '~> 0.4'
   spec.add_development_dependency 'bundler', '~> 2.2'
   spec.add_development_dependency 'rake', '~> 13.0'


### PR DESCRIPTION
Update rubocop from 1.22 to 1.37. Between both versions, rubocop introduced many new cops including:

```
Gemspec/RequireMFA: # new in 1.23
  Enabled: true
Layout/LineContinuationLeadingSpace: # new in 1.31
  Enabled: true
Layout/LineContinuationSpacing: # new in 1.31
  Enabled: true
Lint/ConstantOverwrittenInRescue: # new in 1.31
  Enabled: true
Lint/DuplicateMagicComment: # new in 1.37
  Enabled: true
Lint/NonAtomicFileOperation: # new in 1.31
  Enabled: true
Lint/RefinementImportMethods: # new in 1.27
  Enabled: true
Lint/RequireRangeParentheses: # new in 1.32
  Enabled: true
Lint/UselessRuby2Keywords: # new in 1.23
  Enabled: true
Naming/BlockForwarding: # new in 1.24
  Enabled: true
Security/CompoundHash: # new in 1.28
  Enabled: true
Style/EmptyHeredoc: # new in 1.32
  Enabled: true
Style/EnvHome: # new in 1.29
  Enabled: true
Style/FetchEnvVar: # new in 1.28
  Enabled: true
Style/FileRead: # new in 1.24
  Enabled: true
Style/FileWrite: # new in 1.24
  Enabled: true
Style/MagicCommentFormat: # new in 1.35
  Enabled: true
Style/MapCompactWithConditionalBlock: # new in 1.30
  Enabled: true
Style/MapToHash: # new in 1.24
  Enabled: true
Style/NestedFileDirname: # new in 1.26
  Enabled: true
Style/ObjectThen: # new in 1.28
  Enabled: true
Style/OpenStructUse: # new in 1.23
  Enabled: true
Style/OperatorMethodCall: # new in 1.37
  Enabled: true
Style/RedundantInitialize: # new in 1.27
  Enabled: true
Style/RedundantStringEscape: # new in 1.37
  Enabled: true
Performance/ConcurrentMonotonicTime: # new in 1.12
  Enabled: true
Performance/StringIdentifierArgument: # new in 1.13
  Enabled: true
Rails/ActionControllerFlashBeforeRender: # new in 2.16
  Enabled: true
Rails/ActionControllerTestCase: # new in 2.14
  Enabled: true
Rails/ActiveSupportOnLoad: # new in 2.16
  Enabled: true
Rails/CompactBlank: # new in 2.13
  Enabled: true
Rails/DeprecatedActiveModelErrorsMethods: # new in 2.14
  Enabled: true
Rails/DotSeparatedKeys: # new in 2.15
  Enabled: true
Rails/DuplicateAssociation: # new in 2.14
  Enabled: true
Rails/DuplicateScope: # new in 2.14
  Enabled: true
Rails/DurationArithmetic: # new in 2.13
  Enabled: true
Rails/FreezeTime: # new in 2.16
  Enabled: true
Rails/I18nLazyLookup: # new in 2.14
  Enabled: true
Rails/I18nLocaleTexts: # new in 2.14
  Enabled: true
Rails/MigrationClassName: # new in 2.14
  Enabled: true
Rails/RedundantPresenceValidationOnBelongsTo: # new in 2.13
  Enabled: true
Rails/RootJoinChain: # new in 2.13
  Enabled: true
Rails/RootPathnameMethods: # new in 2.16
  Enabled: true
Rails/RootPublicPath: # new in 2.15
  Enabled: true
Rails/StripHeredoc: # new in 2.15
  Enabled: true
Rails/ToFormattedS: # new in 2.15
  Enabled: true
Rails/ToSWithArgument: # new in 2.16
  Enabled: true
Rails/TopLevelHashWithIndifferentAccess: # new in 2.16
  Enabled: true
Rails/TransactionExitStatement: # new in 2.14
  Enabled: true
Rails/WhereMissing: # new in 2.16
  Enabled: true
RSpec/BeEq: # new in 2.9.0
  Enabled: true
RSpec/BeNil: # new in 2.9.0
  Enabled: true
RSpec/ChangeByZero: # new in 2.11
  Enabled: true
RSpec/ClassCheck: # new in 2.13
  Enabled: true
RSpec/NoExpectationExample: # new in 2.13
  Enabled: true
RSpec/VerifiedDoubleReference: # new in 2.10.0
  Enabled: true
RSpec/Capybara/SpecificFinders: # new in 2.13
  Enabled: true
RSpec/Capybara/SpecificMatcher: # new in 2.12
  Enabled: true
RSpec/FactoryBot/SyntaxMethods: # new in 2.7
  Enabled: true
RSpec/Rails/HaveHttpStatus: # new in 2.12
  Enabled: true
For more information: https://docs.rubocop.org/rubocop/versioning.html
Inspecting 275 files
```