### PR TITLE
Do not enforce shorthand for hash keys. It leads to confusion

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -117,6 +117,7 @@ Style/GuardClause:
 
 Style/HashSyntax:
   EnforcedStyle: ruby19
+  EnforcedShorthandSyntax: never
 
 Style/RedundantSelf:
   Enabled: true
@@ -893,6 +894,7 @@ Lint/UselessRuby2Keywords: # new in 1.23
   Enabled: true
 Naming/BlockForwarding: # new in 1.24
   Enabled: true
+  EnforcedStyle: explicit
 Security/CompoundHash: # new in 1.28
   Enabled: true
 Style/EmptyHeredoc: # new in 1.32

--- a/lib/scc/codestyle/version.rb
+++ b/lib/scc/codestyle/version.rb
@@ -1,5 +1,5 @@
 module Scc
   module Codestyle
-    VERSION = '0.6.3'.freeze
+    VERSION = '0.6.4'.freeze
   end
 end


### PR DESCRIPTION
these kind of construction can lead to confusion:

```
# bad
{foo: foo, bar: bar}

# good
{foo:, bar:}
```

and

```
# bad
def foo(&block)
  bar(&block)
end

# good
def foo(&)
  bar(&)
end
```