### PR TITLE
Fix complains about wrong namespace

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -987,9 +987,9 @@ RSpec/NoExpectationExample: # new in 2.13
   Enabled: true
 RSpec/VerifiedDoubleReference: # new in 2.10.0
   Enabled: true
-RSpec/Capybara/SpecificFinders: # new in 2.13
+Capybara/SpecificFinders: # new in 2.13
   Enabled: true
-RSpec/Capybara/SpecificMatcher: # new in 2.12
+Capybara/SpecificMatcher: # new in 2.12
   Enabled: true
 RSpec/FactoryBot/SyntaxMethods: # new in 2.7
   Enabled: true


### PR DESCRIPTION
Running today rubocop on glue we get the following issues:

```
/home/vpereira/.rvm/gems/ruby-3.2.2/gems/scc-codestyle-0.6.3/default.yml: RSpec/Capybara/SpecificMatcher has the wrong namespace - should be Capybara
/home/vpereira/.rvm/gems/ruby-3.2.2/gems/scc-codestyle-0.6.3/default.yml: RSpec/Capybara/SpecificFinders has the wrong namespace - should be Capybara

```

With this changes, those warnings should be away