### PR TITLE
Update default.yml

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -987,7 +987,7 @@ RSpec/NoExpectationExample: # new in 2.13
   Enabled: true
 RSpec/VerifiedDoubleReference: # new in 2.10.0
   Enabled: true
-RSpec/FactoryBot/SyntaxMethods: # new in 2.7
+FactoryBot/SyntaxMethods: # new in 2.7
   Enabled: true
 RSpec/Rails/HaveHttpStatus: # new in 2.12
   Enabled: true

--- a/lib/scc/codestyle/version.rb
+++ b/lib/scc/codestyle/version.rb
@@ -1,5 +1,5 @@
 module Scc
   module Codestyle
-    VERSION = '0.6.5'.freeze
+    VERSION = '0.6.6'.freeze
   end
 end


### PR DESCRIPTION
Fixes warnings like:

```
/home/jenkins/.bundle-rb3/gems/scc-codestyle-0.6.5/default.yml: RSpec/FactoryBot/SyntaxMethods has the wrong namespace - should be FactoryBot
```