### PR TITLE
Update rubocop rspec

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -16,6 +16,9 @@ require:
   - rubocop-performance
   - rubocop-rails
   - rubocop-rspec
+  - rubocop-rspec_rails
+  - rubocop-capybara
+  - rubocop-factory_bot
   - rubocop-thread_safety
 
 # TODO: team wants to have this enabled (2017-07-13)
@@ -541,7 +544,7 @@ RSpec/EmptyLineAfterSubject:
   Exclude:
     - spec/models/siebel/activity_spec.rb
 
-RSpec/FilePath:
+Rails/FilePath:
   Enabled: true
 
 Rails/InverseOf:
@@ -874,7 +877,7 @@ RSpec/IdenticalEqualityAssertion: # new in 2.4
   Enabled: true
 RSpec/SubjectDeclaration: # new in 2.5
   Enabled: true
-RSpec/Rails/AvoidSetupHook: # new in 2.4
+RSpecRails/AvoidSetupHook: # new in 2.4
   Enabled: true
 Layout/LineContinuationLeadingSpace: # new in 1.31
   Enabled: true
@@ -989,7 +992,7 @@ RSpec/VerifiedDoubleReference: # new in 2.10.0
   Enabled: true
 FactoryBot/SyntaxMethods: # new in 2.7
   Enabled: true
-RSpec/Rails/HaveHttpStatus: # new in 2.12
+RSpecRails/HaveHttpStatus: # new in 2.12
   Enabled: true
 # Both were moved out from the RSpec namespace
 Capybara/SpecificFinders: # new in 2.13

--- a/lib/scc/codestyle/version.rb
+++ b/lib/scc/codestyle/version.rb
@@ -1,5 +1,5 @@
 module Scc
   module Codestyle
-    VERSION = '0.6.6'.freeze
+    VERSION = '0.7.0'.freeze
   end
 end

--- a/scc-codestyle.gemspec
+++ b/scc-codestyle.gemspec
@@ -20,10 +20,13 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'rubocop', '~> 1.37'
+  spec.add_dependency 'rubocop-capybara', '~> 2.21'
+  spec.add_dependency 'rubocop-factory_bot', '~> 2.26'
   spec.add_dependency 'rubocop-performance', '~> 1.15'
   spec.add_dependency 'rubocop-rails', '~> 2.16'
   spec.add_dependency 'rubocop-rake', '~> 0.6'
-  spec.add_dependency 'rubocop-rspec', '~> 2.13'
+  spec.add_dependency 'rubocop-rspec', '~> 3.0.2'
+  spec.add_dependency 'rubocop-rspec_rails', '~> 2.30'
   spec.add_dependency 'rubocop-thread_safety', '~> 0.4'
   spec.add_development_dependency 'bundler', '~> 2.2'
   spec.add_development_dependency 'rake', '~> 13.0'


### PR DESCRIPTION
[rubocop rspec](https://github.com/rubocop/rubocop-rspec) had a major update (version 3) and is splitting code for rails, capybara and factorybot

this pr moves on to version 3

there are lots of new rules.

I would suggest to update this and move update in our project. if needed, we can schedule the update with `rubocop todo` in each project